### PR TITLE
specify path to manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@ $ go build -o kubeapps main.go
 
 ## Usage
 
-Put manifests into `~/.kubeapps` folder.
-
+Put manifests in a particular folder (default to `~/.kubeapps`)
 ```
 # Bring up cluster
 $ kubeapps up
+# Or providing manifests folder
+$ kubeapps up --path /path/to/manifests
 
 # Bring down cluster
 $ kubeapps down

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -30,11 +30,17 @@ var downCmd = &cobra.Command{
 			return err
 		}
 
-		home, err := getHome()
+		kaManifestDir, err := cmd.Flags().GetString("path")
 		if err != nil {
 			return err
 		}
-		kaManifestDir := filepath.Join(home, KUBEAPPS_DIR)
+		if kaManifestDir == "" {
+			home, err := getHome()
+			if err != nil {
+				return err
+			}
+			kaManifestDir = filepath.Join(home, KUBEAPPS_DIR)
+		}
 
 		objs, err := parseObjects(kaManifestDir)
 		if err != nil {
@@ -48,4 +54,5 @@ func init() {
 	RootCmd.AddCommand(downCmd)
 	downCmd.Flags().StringP("namespace", "", api.NamespaceDefault, "Specify namespace for the KubeApps components")
 	downCmd.Flags().Int64("grace-period", -1, "Number of seconds given to resources to terminate gracefully. A negative value is ignored")
+	downCmd.Flags().String("path", "", "Specify folder contains the manifests")
 }

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -25,6 +25,17 @@ var upCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		kaManifestDir, err := cmd.Flags().GetString("path")
+		if err != nil {
+			return err
+		}
+		if kaManifestDir == "" {
+			home, err := getHome()
+			if err != nil {
+				return err
+			}
+			kaManifestDir = filepath.Join(home, KUBEAPPS_DIR)
+		}
 
 		c.Create = true
 
@@ -46,12 +57,6 @@ var upCmd = &cobra.Command{
 		}
 		wd := metadata.AbsPath(cwd)
 
-		home, err := getHome()
-		if err != nil {
-			return err
-		}
-		kaManifestDir := filepath.Join(home, KUBEAPPS_DIR)
-
 		objs, err := parseObjects(kaManifestDir)
 		if err != nil {
 			return err
@@ -65,4 +70,5 @@ func init() {
 	RootCmd.AddCommand(upCmd)
 	upCmd.Flags().StringP("namespace", "", api.NamespaceDefault, "Specify namespace for the KubeApps components")
 	upCmd.Flags().Bool("dry-run", false, "Provides output to be submitted to the server")
+	upCmd.Flags().String("path", "", "Specify folder contains the manifests")
 }


### PR DESCRIPTION
- Default set to `~/.kubeapps`
- Use `--path` flag to provide the specific folder