### PR TITLE
fix k8s version validation on GKE, set DefaultNamespace to `default`

### DIFF
--- a/cmd/down.go
+++ b/cmd/down.go
@@ -10,13 +10,11 @@ var downCmd = &cobra.Command{
 	Short: "uninstall KubeApps components",
 	Long:  `uninstall KubeApps components`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		c := kubecfg.DeleteCmd{}
-		ns, err := cmd.Flags().GetString("namespace")
-		if err != nil {
-			return err
+		c := kubecfg.DeleteCmd{
+			DefaultNamespace: "default",
 		}
-		c.DefaultNamespace = ns
 
+		var err error
 		c.GracePeriod, err = cmd.Flags().GetInt64("grace-period")
 		if err != nil {
 			return err

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -17,13 +17,10 @@ var upCmd = &cobra.Command{
 	Short: "install KubeApps components",
 	Long:  `install KubeApps components`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		c := kubecfg.ApplyCmd{}
-		ns, err := cmd.Flags().GetString("namespace")
-		c.DefaultNamespace = ns
-		if err != nil {
-			return err
+		c := kubecfg.ApplyCmd{
+			DefaultNamespace: "default",
 		}
-
+		var err error
 		c.Create = true
 
 		c.DryRun, err = cmd.Flags().GetBool("dry-run")

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: a87c33313517efd34a132b68f97286161ba0f55d4f652241f17283eb6de81405
-updated: 2017-11-07T13:50:18.914808625+07:00
+updated: 2017-11-08T15:21:50.147688312+07:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -59,7 +59,7 @@ imports:
   - ksonnet-gen/kubespec
   - ksonnet-gen/kubeversion
 - name: github.com/ksonnet/kubecfg
-  version: 2169ce8baf09ef5403f4d5e6eb0e4f1c65df88a9
+  version: 897a3db8a83ca195a2825b1fabe59ffca103e700
   subpackages:
   - metadata
   - pkg/kubecfg

--- a/vendor/github.com/ksonnet/kubecfg/utils/meta.go
+++ b/vendor/github.com/ksonnet/kubecfg/utils/meta.go
@@ -24,6 +24,10 @@ func ParseVersion(v *version.Info) (ret ServerVersion, err error) {
 	if err != nil {
 		return
 	}
+
+	// trim "+" in minor version (happened on GKE)
+	v.Minor = strings.Trim(v.Minor, "+")
+
 	ret.Minor, err = strconv.Atoi(v.Minor)
 	if err != nil {
 		return

--- a/vendor/github.com/ksonnet/kubecfg/utils/meta_test.go
+++ b/vendor/github.com/ksonnet/kubecfg/utils/meta_test.go
@@ -29,6 +29,10 @@ func TestParseVersion(t *testing.T) {
 			input: version.Info{Major: "1", Minor: "6x"},
 			error: true,
 		},
+		{
+			input:    version.Info{Major: "1", Minor: "8+"},
+			expected: ServerVersion{Major: 1, Minor: 8},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
fix #17 