### PR TITLE
[jjo] use only vendor/ dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 kubeapps
 generated
+statik


### PR DESCRIPTION
Instrument `Makefile` to only use dependencies from `vendor/`,
(i.e. ignore local `${GOPATH}/src` tree) to improve local builds
repeat-ability.